### PR TITLE
Add support for multiple virtual host entries

### DIFF
--- a/container.go
+++ b/container.go
@@ -115,12 +115,8 @@ func extractHostnames(_ context.Context, container types.ContainerJSON) []string
 
 	for _, s := range container.Config.Env {
 		if strings.HasPrefix(s, prefix) {
-			// Support multiple hostnames separated with comma.
-			if strings.Index(s, ",") > 0 {
-				return strings.Split(s[len(prefix):], ",")
-			}
-
-			return []string{s[len(prefix):]}
+			// Support multiple hostnames separated with comma and/or space.
+			return strings.FieldsFunc(s[len(prefix):], func(r rune) bool { return r == ' ' || r == ',' })
 		}
 	}
 

--- a/container.go
+++ b/container.go
@@ -52,16 +52,16 @@ func handleContainer(
 		return nil
 	}
 
-	hostname := extractHostname(ctx, container)
+	hostnames := extractHostnames(ctx, container)
 	services := extractServices(ctx, container)
 
-	if hostname != "" {
+	for i, hostname := range hostnames {
 		hostname = rewriteHostname(hostname)
-		addToDNS(eg, hostname, ips, services, container.Name[1:], true)
+		addToDNS(eg, hostname, ips, services, container.Name[1:], i == 0)
 	}
 
 	containerHostname := rewriteHostname(container.Name[1:] + ".local")
-	addToDNS(eg, containerHostname, ips, services, container.Name[1:], hostname == "")
+	addToDNS(eg, containerHostname, ips, services, container.Name[1:], len(hostnames) == 0)
 
 	return nil
 }
@@ -109,13 +109,20 @@ func extractServices(_ context.Context, container types.ContainerJSON) map[strin
 	return services
 }
 
-// extractHostname from a container.
-func extractHostname(_ context.Context, container types.ContainerJSON) string {
-	for _, v := range container.Config.Env {
-		if strings.HasPrefix(v, "VIRTUAL_HOST=") {
-			return v[13:]
+// Extract hostnames from a container, return them as string slices.
+func extractHostnames(_ context.Context, container types.ContainerJSON) []string {
+	prefix := "VIRTUAL_HOST="
+
+	for _, s := range container.Config.Env {
+		if strings.HasPrefix(s, prefix) {
+			// Support multiple hostnames separated with comma.
+			if strings.Index(s, ",") > 0 {
+				return strings.Split(s[len(prefix):], ",")
+			}
+
+			return []string{s[len(prefix):]}
 		}
 	}
 
-	return ""
+	return []string{}
 }


### PR DESCRIPTION
Given a `VIRTUAL_HOST` environment variable containing multiple hostnames like this: `VIRTUAL_HOST=admin.example.com,api.example.com` (which is [supported by nginx-proxy](https://github.com/nginx-proxy/nginx-proxy#multiple-hosts)), I see some sillyness going on in the ldddns logs:

```
Jan 25 15:45:53 anarion ldddns[3781]: Rewrote hostname from "admin.example.com,api.example.com" to "admin-example-com,api-example.local"
Jan 25 15:45:53 anarion ldddns[3781]: added address for "admin-example-com,api-example.local" pointing to "172.18.0.5"
Jan 25 15:45:53 anarion ldddns[3781]: added service "_http._tcp" pointing to "admin-example-com,api-example.local"
```

This is my approach at supporting multiple hostnames. 

However, I'm having trouble testing this locally - any hints? :-)