### PR TITLE
Build a new release when a new go version is released

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     timezone: Europe/Copenhagen
   reviewers:
   - arnested
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+    timezone: Europe/Copenhagen
+  reviewers:
+  - arnested

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.16.5
+
+# The purpose of this Dockerfile is just to "trick" Dependabot into
+# creating a pull request when a new version of Go is released. This
+# way we can create a release and build it with the new Go version.


### PR DESCRIPTION
The purpose of this Dockerfile is just to "trick" Dependabot into creating a pull request when a new version of Go is released. This way we can create a release and build it with the new Go version.
