### PR TITLE
Don't set `DOCKER_API_VERSION` during package install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,11 +60,6 @@ nfpms:
       preremove: "deb/preremove.sh"
       postremove: "deb/postremove.sh"
 
-    deb:
-      triggers:
-        interest_noawait:
-          - /usr/bin/dockerd
-
 announce:
   twitter:
     enabled: true

--- a/deb/postinstall.sh
+++ b/deb/postinstall.sh
@@ -2,20 +2,6 @@
 
 set -e
 
-docker_version=$(/usr/bin/docker version --format '{{ .Server.APIVersion }}')
-
-# Work around systemd reporting dropins being changed on disk.
-# See https://github.com/systemd/systemd/issues/17730
-# Fixed in 248-rc3 (https://github.com/systemd/systemd/pull/18869).
-if [ "$(systemd --version | head -1 | sed -e 's/systemd \([0-9]*\).*/\1/')" -lt "248" ]; then
-    for dropin in $(systemctl cat ldddns.service | grep '^# /etc/systemd/system/ldddns.service.d/' | cut -c 3-); do
-        [ -e "${dropin}" ] && touch "${dropin}"
-    done
-fi
-
-mkdir --parents /usr/lib/systemd/system/ldddns.service.d
-printf "[Service]\nEnvironment=DOCKER_API_VERSION=%s\n" "${docker_version}" > /usr/lib/systemd/system/ldddns.service.d/docker-version.conf
-
 /bin/systemctl daemon-reload
 
 if /bin/systemctl is-active --quiet ldddns.service; then

--- a/deb/postremove.sh
+++ b/deb/postremove.sh
@@ -2,12 +2,4 @@
 
 set -e
 
-if [ -f /usr/lib/systemd/system/ldddns.service.d/docker-version.conf ]; then
-    rm /usr/lib/systemd/system/ldddns.service.d/docker-version.conf
-fi
-
-if [ -d /usr/lib/systemd/system/ldddns.service.d ]; then
-    rmdir --ignore-fail-on-non-empty /usr/lib/systemd/system/ldddns.service.d
-fi
-
 /bin/systemctl daemon-reload


### PR DESCRIPTION
The Docker client library is apparently capable of finding the right version by itself.

This makes our package install and removal much simpler and avoids the need to trigger a package reinstall whenever the Docker daemon gets updated.

Please describe the bug fix or feature you would like to introduce.
