### PR TITLE
Increase dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,21 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     timezone: Europe/Copenhagen
   reviewers:
   - arnested
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     timezone: Europe/Copenhagen
   reviewers:
   - arnested
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     timezone: Europe/Copenhagen
   reviewers:
   - arnested


### PR DESCRIPTION
Check dependencies once per month instead of daily. We'll still get
security updates faster.

Please describe the bug fix or feature you would like to introduce.
