### PR TITLE
arnested/go-version-action doesn't need GITHUB_TOKEN anymore

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,8 +11,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: arnested/go-version-action@v1
       id: go-version
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   go_generate:
     name: Check generated code is up to date
     needs: go-version


### PR DESCRIPTION
<!--
Please describe the bug fix or feature you would like to introduce.
-->
