### PR TITLE
Disable `DynamicUser` for now

### DIFF
--- a/systemd/ldddns.service
+++ b/systemd/ldddns.service
@@ -8,7 +8,6 @@ After=docker.service
 Type=notify
 ExecStart=/usr/libexec/ldddns start
 Restart=on-failure
-DynamicUser=yes
 SupplementaryGroups=docker
 CapabilityBoundingSet=
 DevicePolicy=closed


### PR DESCRIPTION
`DynamicUser=yes` in the systemd service and DBus stopped working together. For now, we disable it.
