### PR TITLE
Remove Twitter

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,8 +64,3 @@ nfpms:
       postinstall: "deb/postinstall.sh"
       preremove: "deb/preremove.sh"
       postremove: "deb/postremove.sh"
-
-announce:
-  twitter:
-    enabled: true
-    message_template: 'ldddns {{.Tag}} is out! Get it at https://ldddns.arnested.dk or run `apt update && apt upgrade`.'

--- a/page/template.html
+++ b/page/template.html
@@ -68,6 +68,6 @@ code.language-console::before {
         {{{content}}}
     </main>
 <hr>
-Copyright &copy; 2020, 2021, 2022, 2023 <a href="https://arnested.dk">Arne Jørgensen</a> &mdash; <a href="https://github.com/arnested/ldddns/blob/main/LICENSE">MIT License</a> &mdash; <a href="https://twitter.com/ldddns">Twitter</a> &mdash; <a href="https://github.com/arnested/ldddns">GitHub</a>
+Copyright &copy; 2020, 2021, 2022, 2023 <a href="https://arnested.dk">Arne Jørgensen</a> &mdash; <a href="https://github.com/arnested/ldddns/blob/main/LICENSE">MIT License</a> &mdash; <a href="https://github.com/arnested/ldddns">GitHub</a>
 </body>
 </html>


### PR DESCRIPTION
Twitter removed the API access and we can no longer post tweets about
new releases automatically.

We abandon the Twitter account.

<!--
Please describe the bug fix or feature you would like to introduce.
-->
