### PR TITLE
Test Go unstable version 1.22rc1

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,12 +20,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - uses: arnested/go-version-action@v1
-      id: go-version
-    - name: Setup Go ${{ steps.go-version.outputs.minimal }}
+    - name: Setup Go
       uses: WillAbides/setup-go-faster@v1.13.0
       with:
-        go-version: ${{ steps.go-version.outputs.minimal }}
+        go-version-file: go.mod
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:

--- a/.github/workflows/go-version.yml
+++ b/.github/workflows/go-version.yml
@@ -35,7 +35,7 @@ jobs:
           delete-branch: true
           title: Update Go version to ${{ steps.go-version.outputs.latest }}
           body: |
-            Update Go version to ${{ steps.go-version.outputs.latest }}
+            Update Go version to ${{ steps.go-version.outputs.latest }}.
 
             See [the release history](https://go.dev/doc/devel/release#go${{ steps.go-version.outputs.latest }}).
           token: ${{ secrets.PAT_TOKEN }}
@@ -49,10 +49,11 @@ jobs:
         with:
           patch-level: true
           unstable: true
-      - uses: arnested/go-version-action@v1
-        id: go-minor-version
-        with:
-          unstable: true
+      - name: Get draft release notes URL
+        id: release-notes
+        run: |
+          # shellcheck disable=SC2086
+          echo "URL=https://tip.golang.org/doc/go$(sed -E 's/([0-9]+\.[0-9]+).*/\1/' <<< '${{ steps.go-version.outputs.latest }}')" >> $GITHUB_OUTPUT
       - name: Setup Go ${{ steps.go-version.outputs.latest }}
         uses: WillAbides/setup-go-faster@v1.13.0
         with:
@@ -66,14 +67,14 @@ jobs:
           commit-message: |
             Test Go unstable version ${{ steps.go-version.outputs.latest }}
 
-            See the draft release notes: https://tip.golang.org/doc/go${{ steps.go-minor-version.outputs.latest }}.
+            See the draft release notes: ${{ steps.release-notes.outputs.URL }}.
           branch: go-version-unstable-test
           delete-branch: true
           title: Test Go unstable version ${{ steps.go-version.outputs.latest }}
           body: |
-            Test Go unstable version ${{ steps.go-version.outputs.latest }}
+            Test Go unstable version ${{ steps.go-version.outputs.latest }}.
 
-            See [the draft release notes](https://tip.golang.org/doc/go${{ steps.go-minor-version.outputs.latest }}).
+            See [the draft release notes](${{ steps.release-notes.outputs.URL }}).
 
             This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!
           token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,12 +10,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: arnested/go-version-action@v1
-        id: go-version
-      - name: Setup Go ${{ steps.go-version.outputs.minimal }}
+      - name: Setup Go
         uses: WillAbides/setup-go-faster@v1.13.0
         with:
-          go-version: ${{ steps.go-version.outputs.minimal }}
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,56 +3,33 @@ name: Build and test
 permissions:
   contents: write
 jobs:
-  go-version:
-    name: Lookup go versions
-    runs-on: ubuntu-22.04
-    outputs:
-      minimal: ${{ steps.go-version.outputs.minimal }}
-      matrix: ${{ steps.go-version.outputs.matrix }}
-      module: ${{ steps.go-version.outputs.module }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: arnested/go-version-action@v1
-      id: go-version
   go_generate:
     name: Check generated code is up to date
-    needs: go-version
     runs-on: ubuntu-22.04
-    env:
-      workdir: go/src/${{ needs.go-version.outputs.module }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        path: ${{env.workdir}}
-    - name: Setup Go ${{ needs.go-version.outputs.minimal }}
+    - name: Setup Go
       uses: WillAbides/setup-go-faster@v1.13.0
       with:
-        go-version: ${{ needs.go-version.outputs.minimal }}
+        go-version-file: go.mod
     - name: go generate
       env:
         GO111MODULE: 'on'
         GOPATH: ${{ github.workspace }}/go
-      working-directory: ${{env.workdir}}
       run: go generate -x
     - name: Diff after go generate
-      working-directory: ${{env.workdir}}
       run: git diff --exit-code
   build_and_test:
     name: Build and test
-    needs: go-version
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        go-version: ${{ fromJSON(needs.go-version.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Setup Go ${{ matrix.go-version }}.x
+    - name: Setup Go
       uses: WillAbides/setup-go-faster@v1.13.0
       with:
-        go-version: ${{ matrix.go-version }}.x
-        ignore-local: true
+        go-version-file: go.mod
     - name: go version
       env:
         GO111MODULE: 'on'
@@ -63,8 +40,6 @@ jobs:
       run: go test -v -race -cover -covermode=atomic -coverprofile=coverage.txt ./...
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v3
-      with:
-        flags: go${{ matrix.go-version }}
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
@@ -77,18 +52,15 @@ jobs:
 
   license_check:
     name: License check
-    needs: go-version
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Go ${{ needs.go-version.outputs.minimal }}
+    - name: Setup Go
       uses: WillAbides/setup-go-faster@v1.13.0
       with:
-        go-version: ${{ needs.go-version.outputs.minimal }}
+        go-version-file: go.mod
     - name: Install wwhrd
-      env:
-        GO111MODULE: 'off'
-      run: go get -u github.com/frapposelli/wwhrd
+      run: go install github.com/frapposelli/wwhrd@latest
     - name: go mod vendor
       env:
         GO111MODULE: 'on'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: arnested/go-version-action@v1
-      id: go-version
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.67.0
       id: version
@@ -25,11 +23,10 @@ jobs:
         DEFAULT_BUMP: patch
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         RELEASE_BRANCHES: main
-    - name: Setup Go ${{ steps.go-version.outputs.latest }}.x
+    - name: Setup Go
       uses: WillAbides/setup-go-faster@v1.13.0
       with:
-        go-version: ${{ steps.go-version.outputs.latest }}.x
-        ignore-local: true
+        go-version-file: go.mod
     - name: go version
       env:
         GO111MODULE: 'on'
@@ -57,7 +54,7 @@ jobs:
       working-directory: site
     - name: apt-ftparchive release
       run: |
-        apt-ftparchive -o APT::FTPArchive::Release::Origin="Arne Jørgensen" -o APT::FTPArchive::Release::Label="${{ steps.go-version.outputs.module }}" release . > Release
+        apt-ftparchive -o APT::FTPArchive::Release::Origin="Arne Jørgensen" release . > Release
         gpg -abs --no-tty --batch --yes -o - Release > Release.gpg
         gpg --clearsign --no-tty --batch --yes -o - Release > InRelease
       working-directory: site

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,8 +35,12 @@ jobs:
     name: Govulncheck
     runs-on: ubuntu-22.04
     steps:
-    - id: govulncheck
-      uses: golang/govulncheck-action@master
-      with:
-        go-version-file: go.mod
-        check-latest: true
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: WillAbides/setup-go-faster@v1.13.0
+        with:
+          go-version-file: go.mod
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@ linters:
   disable:
     - depguard
     - exhaustruct
+    - gocritic
+    - gofumpt
 
 linters-settings:
   exhaustive:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ldddns.arnested.dk
 
-go 1.21.6
+go 1.22rc1
 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect


### PR DESCRIPTION
Test Go unstable version 1.22rc1

See [the draft release notes](https://tip.golang.org/doc/go1.22rc1).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!