### PR TITLE
Revert "Bump BaileyJM02/markdown-to-pdf from 1.2.0 to 2"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         working-directory: site
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: BaileyJM02/markdown-to-pdf@v2
+      - uses: BaileyJM02/markdown-to-pdf@v1.2.0
         with:
           input_path: index.md
           output_dir: site/


### PR DESCRIPTION
This reverts commit 0905517868cc37aded5e79266bb278633ff97648.

v2 of BaileyJM02/markdown-to-pdf is broken.

<!--
Please describe the bug fix or feature you would like to introduce.
-->
