### PR TITLE
Create the draft pull request for unstable version using a PAT token

### DIFF
--- a/.github/workflows/go-version.yml
+++ b/.github/workflows/go-version.yml
@@ -6,8 +6,7 @@ on:
     - cron: '45 * * * *'
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stable:
@@ -86,3 +85,4 @@ jobs:
             See [the draft release notes](${{ steps.release-notes.outputs.URL }}).
 
             This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Otherwise actions will not run on the new pull request.

Adjust the permissions for the autogenerated github.secrets token. Now
that we use a PAT token we don't need anything beside read permission.

<!--
Please describe the bug fix or feature you would like to introduce.
-->
