### PR TITLE
Add preinstaller to check avahi-daemon existence

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,28 @@ fi
 
 set -euo pipefail
 
+ldddns_preinstall(){
+    
+    avahi_install(){
+        echo "Installing avahi-daemon..."
+        sudo apt-get install avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan -y
+    }
+
+    avahi_status(){
+        if [ $(sudo systemctl is-active avahi-daemon) == "inactive" ]; then
+            echo "WARNING: avahi-daemon is inactive! Please activated to make use of ldddns..."
+        fi
+    }
+
+    # Check if avahi-daemon exists
+    echo "Checking dependencies..."
+    which avahi-daemon > /dev/null || avahi_install
+
+    # Will show a warning if avahi-daemon is not active 
+    avahi_status
+
+}
+
 ldddns_install() {
     tmpdir="$(mktemp --directory)"
 
@@ -47,4 +69,5 @@ ldddns_install() {
     fi
 }
 
+ldddns_preinstall
 ldddns_install


### PR DESCRIPTION
<!--
Please describe the bug fix or feature you would like to introduce.
-->

While installing ldddns as sudo, the installation failed on my WSL due to missing service: **avahi-daemon**

I installed a brand new Ubuntu 22.04 machine using WSL just for testing purposes and I found out that **avahi-daemon** does not come out of the box (Maybe I'm wrong)

Nevertheless, checking its existence seemed right as ldddns relights heavily on it 

Another thing:
I only found out that **avahi-daemon** is missing only when I tried installing ldddns as root and not as a sudo user
