### PR TITLE
Fix install script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: '{{ .Tag }}-snapshot-{{ .ShortCommit }}'
+  version_template: '{{ .Tag }}-snapshot-{{ .ShortCommit }}'
 changelog:
   sort: asc
   filters:

--- a/systemd/ldddns.service
+++ b/systemd/ldddns.service
@@ -3,6 +3,7 @@ Description=Local Docker Development DNS
 Documentation=https://ldddns.arnested.dk
 BindTo=docker.service
 After=docker.service
+Requisite=avahi-daemon
 
 [Service]
 Type=notify


### PR DESCRIPTION
- **Use apt-get instead of dpkg for install**
- **Depend on the the avahi-daemon being running**
- **Fix use of deprecated proprty in Goreleaser config**

This was discovered by @sihamouda and reported in #359. Thank you, @sihamouda :tada: 

Fixes #359.