### PR TITLE
Update Go version to 1.23.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ldddns.arnested.dk
 
-go 1.23.2
+go 1.23.3
 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect


### PR DESCRIPTION
Update Go version to 1.23.3.

See [the release history](https://go.dev/doc/devel/release#go1.23.3).