### PR TITLE
Test Go unstable version 1.24rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ldddns.arnested.dk
 
-go 1.23.6
+go 1.24rc3
 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect


### PR DESCRIPTION
Test Go unstable version 1.24rc3.

See [the draft release notes](https://tip.golang.org/doc/go1.24).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!