### PR TITLE
harden entrygroups

### DIFF
--- a/entry_groups.go
+++ b/entry_groups.go
@@ -24,6 +24,8 @@ func newEntryGroups(avahiServer *avahi.Server) *entryGroups {
 
 func (e *entryGroups) get(containerID string) (*avahi.EntryGroup, func(), error) {
 	commit := func() {
+		defer e.mutex.Unlock()
+
 		empty, err := e.groups[containerID].IsEmpty()
 		if err != nil {
 			log.Logf(log.PriErr, "checking whether Avahi entry group is empty: %v", err)
@@ -35,15 +37,15 @@ func (e *entryGroups) get(containerID string) (*avahi.EntryGroup, func(), error)
 				log.Logf(log.PriErr, "error committing: %v", err)
 			}
 		}
-
-		e.mutex.Unlock()
 	}
 
 	e.mutex.Lock()
 	if _, ok := e.groups[containerID]; !ok {
 		entryGroup, err := e.avahiServer.EntryGroupNew()
 		if err != nil {
-			return nil, commit, fmt.Errorf("error creating new entry group: %w", err)
+			e.mutex.Unlock()
+
+			return nil, func() {}, fmt.Errorf("error creating new entry group: %w", err)
 		}
 
 		e.groups[containerID] = entryGroup

--- a/entry_groups.go
+++ b/entry_groups.go
@@ -41,12 +41,12 @@ func (e *entryGroups) get(containerID string) (*avahi.EntryGroup, func(), error)
 
 	e.mutex.Lock()
 	if _, ok := e.groups[containerID]; !ok {
-		eg, err := e.avahiServer.EntryGroupNew()
+		entryGroup, err := e.avahiServer.EntryGroupNew()
 		if err != nil {
 			return nil, commit, fmt.Errorf("error creating new entry group: %w", err)
 		}
 
-		e.groups[containerID] = eg
+		e.groups[containerID] = entryGroup
 	}
 
 	return e.groups[containerID], commit, nil

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -56,7 +56,7 @@ func (c Container) Services() map[string]uint16 {
 			continue
 		}
 
-		//nolint:mnd,gomnd
+		//nolint:mnd
 		if portNumber > 65535 {
 			log.Logf(log.PriErr, "Port number %d is too large", portNumber)
 

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	docker_container "github.com/docker/docker/api/types/container"
 	"ldddns.arnested.dk/internal/container"
 )
 
-func containerJSON() (*types.ContainerJSON, error) {
+func containerJSON() (*docker_container.InspectResponse, error) {
 	jsonFile, err := os.Open("../../testdata/container.json")
 	if err != nil {
 		return nil, fmt.Errorf("opening JSON test data: %w", err)
@@ -25,7 +25,7 @@ func containerJSON() (*types.ContainerJSON, error) {
 	}
 
 	// we initialize our Users array
-	var containerJSON *types.ContainerJSON
+	var containerJSON *docker_container.InspectResponse
 
 	err = json.Unmarshal(byteValue, &containerJSON)
 	if err != nil {

--- a/internal/hostname/hostname_test.go
+++ b/internal/hostname/hostname_test.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	docker_container "github.com/docker/docker/api/types/container"
 	"ldddns.arnested.dk/internal/container"
 	"ldddns.arnested.dk/internal/hostname"
 )
 
-func containerJSON() (*types.ContainerJSON, error) {
+func containerJSON() (*docker_container.InspectResponse, error) {
 	jsonFile, err := os.Open("../../testdata/container.json")
 	if err != nil {
 		return nil, fmt.Errorf("opening JSON test data: %w", err)
@@ -26,7 +26,7 @@ func containerJSON() (*types.ContainerJSON, error) {
 	}
 
 	// we initialize our Users array
-	var containerJSON *types.ContainerJSON
+	var containerJSON *docker_container.InspectResponse
 
 	err = json.Unmarshal(byteValue, &containerJSON)
 	if err != nil {


### PR DESCRIPTION
- **Fix golangci-lint warning**
- **Avoid deprecated type `types.ContainerJSON`**
- **Use longer variable name**
- **Avoid keeping an extrygroup locked**

<!--
Please describe the bug fix or feature you would like to introduce.
-->
