### PR TITLE
Update Go version to 1.25.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ldddns.arnested.dk
 
-go 1.25.0
+go 1.25.1
 
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect


### PR DESCRIPTION
Update Go version to 1.25.1.

See [the release history](https://go.dev/doc/devel/release#go1.25.1).