### PR TITLE
Add an option for starting a gops agent

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - depguard
     - exhaustruct
     - tagliatelle
+    - wsl
   settings:
     errcheck:
       check-type-assertions: true

--- a/entry_groups.go
+++ b/entry_groups.go
@@ -40,6 +40,7 @@ func (e *entryGroups) get(containerID string) (*avahi.EntryGroup, func(), error)
 	}
 
 	e.mutex.Lock()
+
 	if _, ok := e.groups[containerID]; !ok {
 		entryGroup, err := e.avahiServer.EntryGroupNew()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5
 	github.com/coreos/go-systemd/v22 v22.6.0
+	github.com/google/gops v0.3.28
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/gops v0.3.28 h1:2Xr57tqKAmQYRAfG12E+yLcoa2Y42UJo2lOrUFL9ark=
+github.com/google/gops v0.3.28/go.mod h1:6f6+Nl8LcHrzJwi8+p0ii+vmBFSlB4f8cOOkTJ7sk4c=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/holoplot/go-avahi v1.0.1 h1:XcqR2keL4qWRnlxHD5CAOdWpLFZJ+EOUK0vEuylfvvk=


### PR DESCRIPTION
Maybe a [gops](https://github.com/google/gops) agent can help us find out why ldddns sometimes locks up.

This should be considered an “undocumented” feature, and it might be removed again anytime.

The agent won't be started by default but needs to be explicitly enabled by setting `LDDDNS_GOPS=true`.

We also need to loosen systemd's tight grip on the process a bit. Add a `/etc/systemd/system/ldddns.service.d/gops.conf` file with the following content:
```ini
[Service]
Environment=LDDDNS_GOPS=true
PrivateNetwork=no
ProtectHome=no
RestrictAddressFamilies=AF_UNIX AF_INET
IPAddressAllow=127.0.0.1
```