### PR TITLE
Revert "Bump BaileyJM02/markdown-to-pdf from 1.2.0 to 2"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: site
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: BaileyJM02/markdown-to-pdf@v2
+      - uses: BaileyJM02/markdown-to-pdf@v1.2.0
         with:
           input_path: index.md
           output_dir: site/


### PR DESCRIPTION
This reverts commit 8ee8e2ced1e3ed9753ba2a8cb8553c3afb4b9c4d.

<!--
Please describe the bug fix or feature you would like to introduce.
-->
