### PR TITLE
Update Go version to 1.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ldddns.arnested.dk
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5


### PR DESCRIPTION
Update Go version to 1.27.1.

See [the release history](https://go.dev/doc/devel/release#go1.27.1).